### PR TITLE
Allow installation of either tensorflow or tensorflow-gpu

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,9 +30,13 @@ _VERSION = '1.0'
 project_name = 'sonnet'
 
 REQUIRED_PACKAGES = [
-    'tensorflow >= 1.0.1',
     'nose_parameterized >= 0.6.0',
 ]
+
+EXTRA_PACKAGES = {
+    'tensorflow': ['tensorflow>=1.0.1'],
+    'tensorflow with gpu': ['tensorflow-gpu>=1.0.1']
+}
 
 setup(
     name=project_name,
@@ -47,6 +51,7 @@ setup(
     packages=find_packages(),
     entry_points={},
     install_requires=REQUIRED_PACKAGES,
+    extra_requires=EXTRA_PACKAGES,
     tests_require=REQUIRED_PACKAGES,
     # Add in any packaged data.
     include_package_data=True,


### PR DESCRIPTION
The `tensorflow` requirement in `install_requires` prevents installation of `tensorflow-gpu`. This problem is because TensorFlow has two registered Python package names, one for CPU and for GPU. I moved `tensorflow` to be in `extras_require`, so that the user can pick either. (Of course this doesn't solve all problems though.) Am open to other options.

Let me know what you think.