### PR TITLE
Add easy build instructions for Python 3

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ $ bazel build --config=opt :install
 $ ./bazel-bin/install /tmp/sonnet
 ```
 
+By default, the wheel file is built using `python`. You can optionally specify
+another python binary in the previous command to build the wheel file, such as
+`python3`:
+
+```
+$ ./bazel-bin/install /tmp/sonnet python3
+```
+
 `pip install` the generated wheel file:
 
 ```shell

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,14 @@ function main() {
 
   pushd ${TMPDIR}
   echo $(date) : "=== Building wheel"
-  python setup.py bdist_wheel >/dev/null
+
+  if [[ "$2" == "" ]] ; then
+    python setup.py bdist_wheel >/dev/null
+  else
+    # Use custom location of python specified in argument:
+    "$2" setup.py bdist_wheel >/dev/null
+  fi
+
   cp dist/* ${DEST}
   popd
   rm -rf ${TMPDIR}

--- a/setup.py.tmpl
+++ b/setup.py.tmpl
@@ -23,6 +23,7 @@ from setuptools import find_packages
 from setuptools import setup
 from setuptools.command.install import install as InstallCommandBase
 from setuptools.dist import Distribution
+from sys import version
 
 # This version string is semver compatible, but incompatible with pip.
 # For pip, we will remove all '-' characters from this string, and use the
@@ -90,7 +91,9 @@ setup(
         'Intended Audience :: Education',
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: Apache Software License',
-        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: {}'.format(
+            "2.7" if (version[0] == "2") else version[0]
+        ),
         'Topic :: Scientific/Engineering :: Mathematics',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Libraries',


### PR DESCRIPTION
Python 3 compatibility is already possible with Sonnet: deepmind/sonnet#10

However, building for Python 3 requires to make a few changes when using a python binary (or binary location) which is not named `python` (e.g.: `python3`).

I added an optional argument to `install.sh` to specify a custom python location such as what's asked when configuring TensorFlow headers. I added instructions in `README.md`. 

I tested to import snt (version 1.6) from another path and it works:
```
$ python3
>>> import sonnet as snt
>>> import tensorflow as tf
>>> snt.resampler(tf.constant([0.]), tf.constant([0.]))
<tf.Tensor 'resampler/Resampler:0' shape=(1,) dtype=float32>
```

Tested under:
- Sonnet 1.6
- TensorFlow 1.2.1 (with GPU)
- Python 3.6.1 (miniconda)
- Ubuntu 16.04
- Amazon AWS p2 instance (1 x Tesla K80)