### PR TITLE
Fix typo in setup.py.tmpl

### DIFF
--- a/setup.py.tmpl
+++ b/setup.py.tmpl
@@ -75,7 +75,7 @@ setup(
     packages=find_packages(),
     entry_points={},
     install_requires=REQUIRED_PACKAGES,
-    extra_requires=EXTRA_PACKAGES,
+    extras_require=EXTRA_PACKAGES,
     # Add in any packaged data.
     include_package_data=True,
     package_data={'': ['*.txt', '*.rst'], 'sonnet': ['*.so']},


### PR DESCRIPTION
`extra_requires` should really be `extras_require`. See [here](https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords).