### PR TITLE
Fixed minor syntax error for vqvae and vqvae_test

### DIFF
--- a/sonnet/python/modules/nets/vqvae.py
+++ b/sonnet/python/modules/nets/vqvae.py
@@ -87,9 +87,9 @@ class VectorQuantizer(base.AbstractModule):
                   [input_shape])]):
       flat_inputs = tf.reshape(inputs, [-1, self._embedding_dim])
 
-    distances = (tf.reduce_sum(flat_inputs**2, 1, keepdims=True)
+    distances = (tf.reduce_sum(flat_inputs**2, 1, keep_dims=True)
                  - 2 * tf.matmul(flat_inputs, self._w)
-                 + tf.reduce_sum(self._w ** 2, 0, keepdims=True))
+                 + tf.reduce_sum(self._w ** 2, 0, keep_dims=True))
 
     encoding_indices = tf.argmax(- distances, 1)
     encodings = tf.one_hot(encoding_indices, self._num_embeddings)

--- a/sonnet/python/modules/nets/vqvae_test.py
+++ b/sonnet/python/modules/nets/vqvae_test.py
@@ -59,9 +59,9 @@ class VqvaeTest(parameterized.TestCase, tf.test.TestCase):
                                            kwargs['num_embeddings']))
 
     # Check that each input was assigned to the embedding it is closest to.
-    distances = ((inputs_np ** 2).sum(axis=1, keepdims=True)
+    distances = ((inputs_np ** 2).sum(axis=1, keep_dims=True)
                  - 2 * np.dot(inputs_np, embeddings_np)
-                 + (embeddings_np**2).sum(axis=0, keepdims=True))
+                 + (embeddings_np**2).sum(axis=0, keep_dims=True))
     closest_index = np.argmax(-distances, axis=1)
     self.assertAllEqual(closest_index,
                         np.argmax(vq_output_np['encodings'], axis=1))


### PR DESCRIPTION
The parameter keepdims=True fails in TF v1.4 on Python2.7.

I've added an underscore and changed it to:
keep_dims=True

The same change has been made in both vqvae and the vqvae_test files.