### PR TITLE
Fix typo in vqvae_example.ipynb

### DIFF
--- a/sonnet/examples/vqvae_example.ipynb
+++ b/sonnet/examples/vqvae_example.ipynb
@@ -115,7 +115,7 @@
       },
       "source": [
         "# Load the data into Numpy\n",
-        "We compute the variance of the whole training set to normalise the Mean Squared Error below.\n"
+        "We compute the variance of the whole training set to normalize the Mean Squared Error below.\n"
       ]
     },
     {
@@ -176,7 +176,7 @@
       },
       "outputs": [],
       "source": [
-        "def cast_and_normalise_images(data_dict):\n",
+        "def cast_and_normalize_images(data_dict):\n",
         "  \"\"\"Convert images to floating point with the range [0.5, 0.5]\"\"\"\n",
         "  images = data_dict['images']\n",
         "  data_dict['images'] = (tf.cast(images, tf.float32) / 255.0) - 0.5\n",
@@ -377,13 +377,13 @@
         "# Data Loading.\n",
         "train_dataset_iterator = (\n",
         "    tf.data.Dataset.from_tensor_slices(train_data_dict)\n",
-        "    .map(cast_and_normalise_images)\n",
+        "    .map(cast_and_normalize_images)\n",
         "    .shuffle(10000)\n",
         "    .repeat(-1)  # repeat indefinitely\n",
         "    .batch(batch_size)).make_one_shot_iterator()\n",
         "valid_dataset_iterator = (\n",
         "    tf.data.Dataset.from_tensor_slices(valid_data_dict)\n",
-        "    .map(cast_and_normalise_images)\n",
+        "    .map(cast_and_normalize_images)\n",
         "    .repeat(1)  # 1 epoch\n",
         "    .batch(batch_size)).make_initializable_iterator()\n",
         "train_dataset_batch = train_dataset_iterator.get_next()\n",


### PR DESCRIPTION
Changed `cast_and_normalise_images` to `cast_and_normalize_images`, and "normalise" to "normalize".
This seems to be the adopted spelling in all other files (e.g. https://github.com/deepmind/sonnet/search?q=normalize&unscoped_q=normalize).