### PR TITLE
Adding automatic mixed precision training support - RNN and Relational Memory Core examples

### DIFF
--- a/sonnet/examples/rmc_nth_farthest.py
+++ b/sonnet/examples/rmc_nth_farthest.py
@@ -53,7 +53,8 @@ flags.DEFINE_integer("num_features", 4, "Feature size per object.")
 flags.DEFINE_integer("epochs", 1000000, "Total training epochs.")
 flags.DEFINE_integer("log_stride", 100, "Iterations between reports.")
 tf.flags.DEFINE_boolean("gpu_auto_mixed_precision", False,
-                        "Enable GPU automatic mixed precision training. TensorFlow>=1.14 is required.")
+                        "Enable GPU automatic mixed precision training. "
+                        "TensorFlow>=1.14 is required.")
 
 
 class SequenceModel(snt.AbstractModule):
@@ -173,11 +174,12 @@ def build_and_train(iterations, log_stride, test=False, gpu_auto_mixed_precision
         FLAGS.min_learning_rate
     ])
     optimizer = tf.train.AdamOptimizer(learning_rate_op)
-    if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1' or gpu_auto_mixed_precision:
+    if os.environ.get("TF_ENABLE_AUTO_MIXED_PRECISION", default="0") == "1" \
+       or gpu_auto_mixed_precision:
         tf_version_list = tf.__version__.split(".")
         if int(tf_version_list[0]) < 2:
             if int(tf_version_list[1]) < 14:
-                raise (RuntimeError("TensorFlow 1.14.0 or newer is required for automatic precision."))
+                raise RuntimeError("TensorFlow>=1.14 is required for automatic precision.")
         optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
     train_loss, _ = loss_fn(inputs_train, labels_train)
     step_op = optimizer.minimize(train_loss, global_step=global_step)
@@ -212,7 +214,8 @@ def build_and_train(iterations, log_stride, test=False, gpu_auto_mixed_precision
 
 
 def main(unused_argv):
-  build_and_train(FLAGS.epochs, FLAGS.log_stride, gpu_auto_mixed_precision=FLAGS.gpu_auto_mixed_precision)
+  build_and_train(FLAGS.epochs, FLAGS.log_stride,
+                  gpu_auto_mixed_precision=FLAGS.gpu_auto_mixed_precision)
 
 if __name__ == "__main__":
   tf.app.run()

--- a/sonnet/examples/rnn_shakespeare.py
+++ b/sonnet/examples/rnn_shakespeare.py
@@ -52,7 +52,7 @@ tf.flags.DEFINE_string("checkpoint_dir", "/tmp/tf/rnn_shakespeare",
 tf.flags.DEFINE_integer("checkpoint_interval", 500,
                         "Checkpointing step interval.")
 tf.flags.DEFINE_boolean("gpu_auto_mixed_precision", False,
-                        "Enable GPU automatic mixed precision training")
+                        "Enable GPU automatic mixed precision training. TensorFlow>=1.14 is required.")
 
 
 def _configure_saver(checkpoint_dir, checkpoint_interval):

--- a/sonnet/examples/rnn_shakespeare.py
+++ b/sonnet/examples/rnn_shakespeare.py
@@ -52,7 +52,8 @@ tf.flags.DEFINE_string("checkpoint_dir", "/tmp/tf/rnn_shakespeare",
 tf.flags.DEFINE_integer("checkpoint_interval", 500,
                         "Checkpointing step interval.")
 tf.flags.DEFINE_boolean("gpu_auto_mixed_precision", False,
-                        "Enable GPU automatic mixed precision training. TensorFlow>=1.14 is required.")
+                        "Enable GPU automatic mixed precision training. "
+                        "TensorFlow>=1.14 is required.")
 
 
 def _configure_saver(checkpoint_dir, checkpoint_interval):
@@ -153,11 +154,12 @@ def build_graph(lstm_depth=3, batch_size=32, num_embedding=32, num_hidden=128,
   # Define optimizer and training step.
   optimizer = tf.train.AdamOptimizer(
       learning_rate, epsilon=optimizer_epsilon)
-  if os.environ.get('TF_ENABLE_AUTO_MIXED_PRECISION', default='0') == '1' or gpu_auto_mixed_precision:
+  if os.environ.get("TF_ENABLE_AUTO_MIXED_PRECISION", default="0") == "1" \
+     or gpu_auto_mixed_precision:
       tf_version_list = tf.__version__.split(".")
       if int(tf_version_list[0]) < 2:
           if int(tf_version_list[1]) < 14:
-              raise(RuntimeError("TensorFlow 1.14.0 or newer is required for automatic precision."))
+              raise RuntimeError("TensorFlow>=1.14 is required for automatic precision.")
       optimizer = tf.train.experimental.enable_mixed_precision_graph_rewrite(optimizer)
   train_step = optimizer.apply_gradients(
       zip(grads, trainable_variables),


### PR DESCRIPTION
Automatic Mixed Precision training on GPU for Tensorflow has been recently introduced:

https://medium.com/tensorflow/automatic-mixed-precision-in-tensorflow-for-faster-ai-training-on-nvidia-gpus-6033234b2540

This PR adds GPU automatic mixed precision training to `sonnet` RNN and Relational Memory Core examples via setting a single OS flag:
```
export TF_ENABLE_AUTO_MIXED_PRECISION=1
```
Alternatively, it can also be enabled by directly calling the example with an appropriate flag:
```
python sonnet/examples/rnn_shakespeare.py --gpu_auto_mixed_precision
python sonnet/examples/rmc_nth_farthest.py --gpu_auto_mixed_precision
```