### PR TITLE
Fixed python version on mlp notebook

### DIFF
--- a/examples/mlp_on_mnist.ipynb
+++ b/examples/mlp_on_mnist.ipynb
@@ -670,8 +670,8 @@
       "version": "0.3.2"
     },
     "kernelspec": {
-      "display_name": "Python 2",
-      "name": "python2"
+      "display_name": "Python 3",
+      "name": "python3"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
On colab the default python version for the notebook is python 2, but it needs python 3 to work.