### PR TITLE
Resolve doc build issues (#162, #163)

### DIFF
--- a/sonnet/src/axis_norm.py
+++ b/sonnet/src/axis_norm.py
@@ -83,9 +83,9 @@ class LayerNorm(base.Module):
     Args:
       axis: An ``int``, ``slice`` or sequence of ``int``\s representing the axes
         which should be normalized across. Typical usages are: ``1`` or ``-1``
-          for normalization over just the channels and ``slice(1, None)``,
-          ``slice(2, None)`` for normalization over the spatial and channel
-          dimensions whilst avoiding the batch and/or time dimensions.
+        for normalization over just the channels and ``slice(1, None)``,
+        ``slice(2, None)`` for normalization over the spatial and channel
+        dimensions whilst avoiding the batch and/or time dimensions.
       create_scale: ``bool`` representing whether to create a trainable scale
         per channel applied after the normalization.
       create_offset: ``bool`` representing whether to create a trainable offset

--- a/sonnet/src/mixed_precision.py
+++ b/sonnet/src/mixed_precision.py
@@ -145,14 +145,14 @@ def scope(dtype: tf.DType):
 
   The global type is reset to its original value when the context is exited.::
 
-       snt.mixed_precision.enable(tf.float32)
-       snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
-       mod = snt.Linear(10)
+      snt.mixed_precision.enable(tf.float32)
+      snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
+      mod = snt.Linear(10)
 
-       with snt.mixed_precision.scope(tf.float16):
-           y = mod(tf.ones([1, 1]))  # First call will be done in F32.
-           y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
-       y = mod(tf.ones([1, 1]))  # Outside the scope will be done in F32.
+      with snt.mixed_precision.scope(tf.float16):
+          y = mod(tf.ones([1, 1]))  # First call will be done in F32.
+          y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
+      y = mod(tf.ones([1, 1]))  # Outside the scope will be done in F32.
 
   Args:
     dtype: type to set the mixed precision mode to.

--- a/sonnet/src/mixed_precision.py
+++ b/sonnet/src/mixed_precision.py
@@ -75,15 +75,13 @@ def _cast_call(f, new_dtype, args, kwargs):
 
 
 def modes(valid_types):
-  """Decorate a function to cast inputs/outputs to different precision.
+  """Decorate a function to cast inputs/outputs to different precision.::
 
-      .. code-block:: python
-
-          snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
-          mod = snt.Linear(10)
-          snt.mixed_precision.enable(tf.float16)
-          y = mod(tf.ones([1, 1]))  # First call will be done in F32.
-          y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
+        snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
+        mod = snt.Linear(10)
+        snt.mixed_precision.enable(tf.float16)
+        y = mod(tf.ones([1, 1]))  # First call will be done in F32.
+        y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
 
   Args:
     valid_types: Collection of types that the function being decorated is legal
@@ -146,18 +144,16 @@ def modes(valid_types):
 def scope(dtype: tf.DType):
   """Temporarily set the global mixed precision type to dtype.
 
-  The global type is reset to its original value when the context is exited.
+  The global type is reset to its original value when the context is exited.::
 
-  .. code-block:: python
+       snt.mixed_precision.enable(tf.float32)
+       snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
+       mod = snt.Linear(10)
 
-         snt.mixed_precision.enable(tf.float32)
-         snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
-         mod = snt.Linear(10)
-
-         with snt.mixed_precision.scope(tf.float16):
-             y = mod(tf.ones([1, 1]))  # First call will be done in F32.
-             y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
-         y = mod(tf.ones([1, 1]))  # Outside the scope will be done in F32.
+       with snt.mixed_precision.scope(tf.float16):
+           y = mod(tf.ones([1, 1]))  # First call will be done in F32.
+           y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
+       y = mod(tf.ones([1, 1]))  # Outside the scope will be done in F32.
 
   Args:
     dtype: type to set the mixed precision mode to.

--- a/sonnet/src/mixed_precision.py
+++ b/sonnet/src/mixed_precision.py
@@ -77,12 +77,13 @@ def _cast_call(f, new_dtype, args, kwargs):
 def modes(valid_types):
   """Decorate a function to cast inputs/outputs to different precision.
 
-      snt.Linear.__call__ = snt.mixed_precision.modes(
-        [tf.float32, tf.float16])(snt.Linear.__call__)
-      mod = snt.Linear(10)
-      snt.mixed_precision.enable(tf.float16)
-      y = mod(tf.ones([1, 1]))  # First call will be done in F32.
-      y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
+      .. code-block:: python
+
+          snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
+          mod = snt.Linear(10)
+          snt.mixed_precision.enable(tf.float16)
+          y = mod(tf.ones([1, 1]))  # First call will be done in F32.
+          y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
 
   Args:
     valid_types: Collection of types that the function being decorated is legal
@@ -147,14 +148,16 @@ def scope(dtype: tf.DType):
 
   The global type is reset to its original value when the context is exited.
 
-      snt.mixed_precision.enable(tf.float32)
-      snt.Linear.__call__ = snt.mixed_precision.modes(
-        [tf.float32, tf.float16])(snt.Linear.__call__)
-      mod = snt.Linear(10)
-      with snt.mixed_precision.scope(tf.float16):
-        y = mod(tf.ones([1, 1]))  # First call will be done in F32.
-        y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
-      y = mod(tf.ones([1, 1]))  # Outside the scope will be done in F32.
+  .. code-block:: python
+
+         snt.mixed_precision.enable(tf.float32)
+         snt.Linear.__call__ = snt.mixed_precision.modes([tf.float32, tf.float16])(snt.Linear.__call__)
+         mod = snt.Linear(10)
+
+         with snt.mixed_precision.scope(tf.float16):
+             y = mod(tf.ones([1, 1]))  # First call will be done in F32.
+             y = mod(tf.ones([1, 1]))  # MatMul/Add will be done in F16.
+         y = mod(tf.ones([1, 1]))  # Outside the scope will be done in F32.
 
   Args:
     dtype: type to set the mixed precision mode to.

--- a/sonnet/src/mixed_precision.py
+++ b/sonnet/src/mixed_precision.py
@@ -86,12 +86,13 @@ def modes(valid_types):
 
   Args:
     valid_types: Collection of types that the function being decorated is legal
-      to run in.
+    to run in.
 
   Returns:
     A decorator that will cast the inputs and outputs of the decorated function
     according to the global mixed precision policy and the functions eligibility
     for mixed precision.
+
   """
   mp_id = uuid.uuid4()
 

--- a/sonnet/src/mixed_precision.py
+++ b/sonnet/src/mixed_precision.py
@@ -91,7 +91,6 @@ def modes(valid_types):
     A decorator that will cast the inputs and outputs of the decorated function
     according to the global mixed precision policy and the functions eligibility
     for mixed precision.
-
   """
   mp_id = uuid.uuid4()
 

--- a/sonnet/src/nets/vqvae.py
+++ b/sonnet/src/nets/vqvae.py
@@ -97,7 +97,6 @@ class VectorQuantizer(base.Module):
         of the quantized space each input element was mapped to.
         encoding_indices: Tensor containing the discrete encoding indices, ie
         which element of the quantized space each input element was mapped to.
-
     """
     flat_inputs = tf.reshape(inputs, [-1, self.embedding_dim])
 
@@ -242,7 +241,6 @@ class VectorQuantizerEMA(base.Module):
         of the quantized space each input element was mapped to.
         encoding_indices: Tensor containing the discrete encoding indices, ie
         which element of the quantized space each input element was mapped to.
-
     """
     flat_inputs = tf.reshape(inputs, [-1, self.embedding_dim])
 

--- a/sonnet/src/nets/vqvae.py
+++ b/sonnet/src/nets/vqvae.py
@@ -94,9 +94,10 @@ class VectorQuantizer(base.Module):
         loss: Tensor containing the loss to optimize.
         perplexity: Tensor containing the perplexity of the encodings.
         encodings: Tensor containing the discrete encodings, ie which element
-          of the quantized space each input element was mapped to.
+        of the quantized space each input element was mapped to.
         encoding_indices: Tensor containing the discrete encoding indices, ie
-          which element of the quantized space each input element was mapped to.
+        which element of the quantized space each input element was mapped to.
+
     """
     flat_inputs = tf.reshape(inputs, [-1, self.embedding_dim])
 
@@ -238,9 +239,10 @@ class VectorQuantizerEMA(base.Module):
         loss: Tensor containing the loss to optimize.
         perplexity: Tensor containing the perplexity of the encodings.
         encodings: Tensor containing the discrete encodings, ie which element
-          of the quantized space each input element was mapped to.
+        of the quantized space each input element was mapped to.
         encoding_indices: Tensor containing the discrete encoding indices, ie
-          which element of the quantized space each input element was mapped to.
+        which element of the quantized space each input element was mapped to.
+
     """
     flat_inputs = tf.reshape(inputs, [-1, self.embedding_dim])
 

--- a/sonnet/src/optimizers/momentum.py
+++ b/sonnet/src/optimizers/momentum.py
@@ -87,7 +87,8 @@ class Momentum(base.Optimizer):
     And when using Nesterov momentum (`use_nesterov=True`) it applies:
 
         accum_t <- momentum * accum_{t-1} + update
-        parameter <- parameter - (learning_rate * update + learning_rate * momentum * accum_t)
+        parameter <- parameter - (learning_rate * update +
+        learning_rate * momentum * accum_t)
 
     Args:
       updates: A list of updates to apply to parameters. Updates are often

--- a/sonnet/src/optimizers/momentum.py
+++ b/sonnet/src/optimizers/momentum.py
@@ -87,8 +87,7 @@ class Momentum(base.Optimizer):
     And when using Nesterov momentum (`use_nesterov=True`) it applies:
 
         accum_t <- momentum * accum_{t-1} + update
-        parameter <- parameter - (learning_rate * update +
-                                  learning_rate * momentum * accum_t)
+        parameter <- parameter - (learning_rate * update + learning_rate * momentum * accum_t)
 
     Args:
       updates: A list of updates to apply to parameters. Updates are often


### PR DESCRIPTION
Hi!

1. Fixing #162 
There have been 11 warnings while building docs. They were mostly indentation errors. This may cause future issues, I resolved them at 29c2adf182c1bb7e9a03bcd4f5909fde7889e34c. Currently 0 warnings.

2. Fixing #163 
https://sonnet.readthedocs.io/en/latest/api.html#modes
https://sonnet.readthedocs.io/en/latest/api.html#scope
code examples weren't rendered properly before. Fixed here:  0e8d1c40ec212b83610f3dacdc9d4f809eb559d7