### PR TITLE
refactoring: early return 'if else' syntax -> 'if' syntax

### DIFF
--- a/sonnet/src/bias.py
+++ b/sonnet/src/bias.py
@@ -125,8 +125,7 @@ class Bias(base.Module):
     self._initialize(inputs)
     if multiplier is not None:
       return inputs + (self.b * multiplier)
-    else:
-      return inputs + self.b
+    return inputs + self.b
 
 
 def calculate_bias_shape(input_shape: types.ShapeLike,


### PR DESCRIPTION
I think 'if syntax' is better than 'if else syntax' in the early return pattern.
Thanks You!