### PR TITLE
fix dtype of one-hot indicators in vqvae.py

### DIFF
--- a/sonnet/src/nets/vqvae.py
+++ b/sonnet/src/nets/vqvae.py
@@ -106,7 +106,9 @@ class VectorQuantizer(base.Module):
         tf.reduce_sum(self.embeddings**2, 0, keepdims=True))
 
     encoding_indices = tf.argmax(-distances, 1)
-    encodings = tf.one_hot(encoding_indices, self.num_embeddings)
+    encodings = tf.one_hot(encoding_indices,
+                           self.num_embeddings,
+                           dtype=distances.dtype)
 
     # NB: if your code crashes with a reshape error on the line below about a
     # Tensor containing the wrong number of values, then the most likely cause
@@ -250,7 +252,9 @@ class VectorQuantizerEMA(base.Module):
         tf.reduce_sum(self.embeddings**2, 0, keepdims=True))
 
     encoding_indices = tf.argmax(-distances, 1)
-    encodings = tf.one_hot(encoding_indices, self.num_embeddings)
+    encodings = tf.one_hot(encoding_indices,
+                           self.num_embeddings,
+                           dtype=distances.dtype)
 
     # NB: if your code crashes with a reshape error on the line below about a
     # Tensor containing the wrong number of values, then the most likely cause


### PR DESCRIPTION
`tf.one_hot` defaults to `tf.float32` if no dtype is provided. This prevents `VectorQuantizerEMA` from running if its dtype is specified as `tf.float64` at init time (since the EMA tries to subtract a `tf.float32` - the one hot indicator tensor - from a `tf.float64`). This is easily fixed by passing a dtype argument to `tf.one_hot`.