### PR TITLE
Carefully move some internal methods of recurrent.py to a dedicated utils file

### DIFF
--- a/sonnet/src/BUILD
+++ b/sonnet/src/BUILD
@@ -371,6 +371,7 @@ snt_py_library(
     srcs = ["recurrent_internals.py"],
     deps = [
         # pip: tensorflow
+        # pip: tree
     ],
 )
 

--- a/sonnet/src/BUILD
+++ b/sonnet/src/BUILD
@@ -367,6 +367,12 @@ snt_py_test(
 )
 
 snt_py_library(
+    name = "recurrent_internals",
+    srcs = ["recurrent_internals.py"],
+    deps = [],
+)
+
+snt_py_library(
     name = "recurrent",
     srcs = ["recurrent.py"],
     deps = [
@@ -377,6 +383,7 @@ snt_py_library(
         ":once",
         ":types",
         ":utils",
+        ":recurrent_internals"
         # pip: six
         # pip: tensorflow
         # pip: tree

--- a/sonnet/src/BUILD
+++ b/sonnet/src/BUILD
@@ -369,7 +369,9 @@ snt_py_test(
 snt_py_library(
     name = "recurrent_internals",
     srcs = ["recurrent_internals.py"],
-    deps = [],
+    deps = [
+        # pip: tensorflow
+    ],
 )
 
 snt_py_library(

--- a/sonnet/src/recurrent.py
+++ b/sonnet/src/recurrent.py
@@ -32,7 +32,7 @@ from sonnet.src import linear
 from sonnet.src import once
 from sonnet.src import types
 from sonnet.src import utils
-from sonnet.src.recurrent_internals import _check_inputs_dtype, _safe_where
+from sonnet.src.recurrent_internals import _check_inputs_dtype, _safe_where, _unstack_input_sequence
 
 import tensorflow as tf
 import tree
@@ -393,46 +393,6 @@ def dynamic_unroll(
   output_sequence = tree.map_structure(tf.TensorArray.stack, output_tas)
   return output_sequence, state
 
-
-def _unstack_input_sequence(input_sequence):
-  r"""Unstacks the input sequence into a nest of :tf:`TensorArray`\ s.
-
-  This allows to traverse the input sequence using :tf:`TensorArray.read`
-  instead of a slice, avoiding O(sliced tensor) slice gradient
-  computation during the backwards pass.
-
-  Args:
-    input_sequence: See :func:`dynamic_unroll` or :func:`static_unroll`.
-
-  Returns:
-    num_steps: Number of steps in the input sequence.
-    input_tas: An arbitrarily nested structure of :tf:`TensorArray`\ s of
-      size ``num_steps``.
-
-  Raises:
-    ValueError: If tensors in ``input_sequence`` have inconsistent number
-      of steps or the number of steps is 0.
-  """
-  flat_input_sequence = tree.flatten(input_sequence)
-  all_num_steps = {i.shape[0] for i in flat_input_sequence}
-  if len(all_num_steps) > 1:
-    raise ValueError(
-        "input_sequence tensors must have consistent number of time steps")
-  [num_steps] = all_num_steps
-  if num_steps == 0:
-    raise ValueError("input_sequence must have at least a single time step")
-  elif num_steps is None:
-    # Number of steps is not known statically, fall back to dynamic shape.
-    num_steps = tf.shape(flat_input_sequence[0])[0]
-    # TODO(b/141910613): uncomment when the bug is fixed.
-    # for i in flat_input_sequence[1:]:
-    #   tf.debugging.assert_equal(
-    #       tf.shape(i)[0], num_steps,
-    #       "input_sequence tensors must have consistent number of time steps")
-
-  input_tas = tree.map_structure(
-      lambda i: tf.TensorArray(i.dtype, num_steps).unstack(i), input_sequence)
-  return num_steps, input_tas
 
 def _rnn_step(core, input_tas, sequence_length, t, prev_outputs, prev_state):
   """Performs a single RNN step optionally accounting for variable length."""

--- a/sonnet/src/recurrent.py
+++ b/sonnet/src/recurrent.py
@@ -20,7 +20,6 @@ from __future__ import division
 from __future__ import print_function
 
 import abc
-import collections
 import functools
 
 import six
@@ -31,7 +30,7 @@ from sonnet.src import linear
 from sonnet.src import once
 from sonnet.src import types
 from sonnet.src import utils
-from sonnet.src.recurrent_internals import _check_inputs_dtype, _unstack_input_sequence, _specialize_per_device, _rnn_step
+from sonnet.src.recurrent_internals import _check_inputs_dtype, _unstack_input_sequence, _specialize_per_device, _rnn_step, LSTMState
 
 import tensorflow as tf
 import tree
@@ -663,9 +662,6 @@ def deep_rnn_with_residual_connections(
   return _LegacyDeepRNN([_ResidualWrapper(l) for l in layers],
                         skip_connections=False,
                         name=name)
-
-
-LSTMState = collections.namedtuple("LSTMState", ["hidden", "cell"])
 
 
 class LSTM(RNNCore):

--- a/sonnet/src/recurrent.py
+++ b/sonnet/src/recurrent.py
@@ -32,6 +32,7 @@ from sonnet.src import linear
 from sonnet.src import once
 from sonnet.src import types
 from sonnet.src import utils
+from sonnet.src.recurrent_internals import _check_inputs_dtype
 
 import tensorflow.compat.v1 as tf1
 import tensorflow as tf
@@ -1719,9 +1720,9 @@ class CuDNNGRU(RNNCore):
         name="w_h")
     self.b = tf.Variable(self._b_init([3 * self._hidden_size], dtype), name="b")
 
-
-def _check_inputs_dtype(inputs, expected_dtype):
-  if inputs.dtype is not expected_dtype:
-    raise TypeError("inputs must have dtype {!r}, got {!r}".format(
-        expected_dtype, inputs.dtype))
-  return expected_dtype
+#
+# def _check_inputs_dtype(inputs, expected_dtype):
+#   if inputs.dtype is not expected_dtype:
+#     raise TypeError("inputs must have dtype {!r}, got {!r}".format(
+#         expected_dtype, inputs.dtype))
+#   return expected_dtype

--- a/sonnet/src/recurrent_internals.py
+++ b/sonnet/src/recurrent_internals.py
@@ -36,7 +36,7 @@ from tensorflow.python.eager import function as function_lib
 LSTMState = collections.namedtuple("LSTMState", ["hidden", "cell"])
 
 
-def _lstm_fn(inputs, prev_state, w_i, w_h, b, projection=None):
+def lstm_fn(inputs, prev_state, w_i, w_h, b, projection=None):
   """Compute one step of an LSTM."""
   gates_x = tf.matmul(inputs, w_i)
   gates_h = tf.matmul(prev_state.hidden, w_h)
@@ -55,7 +55,7 @@ def _lstm_fn(inputs, prev_state, w_i, w_h, b, projection=None):
   return next_hidden, LSTMState(hidden=next_hidden, cell=next_cell)
 
 
-def _rnn_step(core, input_tas, sequence_length, t, prev_outputs, prev_state):
+def rnn_step(core, input_tas, sequence_length, t, prev_outputs, prev_state):
   """Performs a single RNN step optionally accounting for variable length."""
   outputs, state = core(
       tree.map_structure(lambda i: i.read(t), input_tas), prev_state)
@@ -85,14 +85,14 @@ def _safe_where(condition, x, y):  # pylint: disable=g-doc-args
   return tf1.where(condition, x, y)
 
 
-def _check_inputs_dtype(inputs, expected_dtype):
+def check_inputs_dtype(inputs, expected_dtype):
   if inputs.dtype is not expected_dtype:
     raise TypeError("inputs must have dtype {!r}, got {!r}".format(
         expected_dtype, inputs.dtype))
   return expected_dtype
 
 
-def _unstack_input_sequence(input_sequence):
+def unstack_input_sequence(input_sequence):
   r"""Unstacks the input sequence into a nest of :tf:`TensorArray`\ s.
 
   This allows to traverse the input sequence using :tf:`TensorArray.read`
@@ -134,7 +134,7 @@ def _unstack_input_sequence(input_sequence):
 
 
 # TODO(b/133740216): consider upstreaming into TensorFlow.
-def _specialize_per_device(api_name, specializations, default):
+def specialize_per_device(api_name, specializations, default):
   """Create a :tf:`function` specialized per-device.
 
   Args:

--- a/sonnet/src/recurrent_internals.py
+++ b/sonnet/src/recurrent_internals.py
@@ -15,6 +15,8 @@
 """Utils for Recurrent Neural Network cores."""
 
 import tensorflow.compat.v1 as tf1
+import tensorflow as tf
+import tree
 
 
 def _check_inputs_dtype(inputs, expected_dtype):
@@ -32,3 +34,45 @@ def _safe_where(condition, x, y):  # pylint: disable=g-doc-args
     return y
   # TODO(tomhennigan) Broadcasting with SelectV2 is currently broken.
   return tf1.where(condition, x, y)
+
+
+
+def _unstack_input_sequence(input_sequence):
+  r"""Unstacks the input sequence into a nest of :tf:`TensorArray`\ s.
+
+  This allows to traverse the input sequence using :tf:`TensorArray.read`
+  instead of a slice, avoiding O(sliced tensor) slice gradient
+  computation during the backwards pass.
+
+  Args:
+    input_sequence: See :func:`dynamic_unroll` or :func:`static_unroll`.
+
+  Returns:
+    num_steps: Number of steps in the input sequence.
+    input_tas: An arbitrarily nested structure of :tf:`TensorArray`\ s of
+      size ``num_steps``.
+
+  Raises:
+    ValueError: If tensors in ``input_sequence`` have inconsistent number
+      of steps or the number of steps is 0.
+  """
+  flat_input_sequence = tree.flatten(input_sequence)
+  all_num_steps = {i.shape[0] for i in flat_input_sequence}
+  if len(all_num_steps) > 1:
+    raise ValueError(
+        "input_sequence tensors must have consistent number of time steps")
+  [num_steps] = all_num_steps
+  if num_steps == 0:
+    raise ValueError("input_sequence must have at least a single time step")
+  elif num_steps is None:
+    # Number of steps is not known statically, fall back to dynamic shape.
+    num_steps = tf.shape(flat_input_sequence[0])[0]
+    # TODO(b/141910613): uncomment when the bug is fixed.
+    # for i in flat_input_sequence[1:]:
+    #   tf.debugging.assert_equal(
+    #       tf.shape(i)[0], num_steps,
+    #       "input_sequence tensors must have consistent number of time steps")
+
+  input_tas = tree.map_structure(
+      lambda i: tf.TensorArray(i.dtype, num_steps).unstack(i), input_sequence)
+  return num_steps, input_tas

--- a/sonnet/src/recurrent_internals.py
+++ b/sonnet/src/recurrent_internals.py
@@ -14,6 +14,7 @@
 # ============================================================================
 """Utils for Recurrent Neural Network cores."""
 
+import collections
 import functools
 import uuid
 
@@ -26,6 +27,9 @@ import tree
 from tensorflow.python import context as context_lib
 from tensorflow.python.eager import function as function_lib
 # pylint: enable=g-direct-tensorflow-import
+
+
+LSTMState = collections.namedtuple("LSTMState", ["hidden", "cell"])
 
 
 def _rnn_step(core, input_tas, sequence_length, t, prev_outputs, prev_state):

--- a/sonnet/src/recurrent_internals.py
+++ b/sonnet/src/recurrent_internals.py
@@ -14,6 +14,10 @@
 # ============================================================================
 """Utils for Recurrent Neural Network cores."""
 
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
 import collections
 import functools
 import uuid

--- a/sonnet/src/recurrent_internals.py
+++ b/sonnet/src/recurrent_internals.py
@@ -1,0 +1,22 @@
+# Copyright 2019 The Sonnet Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or  implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ============================================================================
+"""Utils for Recurrent Neural Network cores."""
+
+
+def _check_inputs_dtype(inputs, expected_dtype):
+  if inputs.dtype is not expected_dtype:
+    raise TypeError("inputs must have dtype {!r}, got {!r}".format(
+        expected_dtype, inputs.dtype))
+  return expected_dtype

--- a/sonnet/src/recurrent_internals.py
+++ b/sonnet/src/recurrent_internals.py
@@ -14,9 +14,21 @@
 # ============================================================================
 """Utils for Recurrent Neural Network cores."""
 
+import tensorflow.compat.v1 as tf1
+
 
 def _check_inputs_dtype(inputs, expected_dtype):
   if inputs.dtype is not expected_dtype:
     raise TypeError("inputs must have dtype {!r}, got {!r}".format(
         expected_dtype, inputs.dtype))
   return expected_dtype
+
+
+def _safe_where(condition, x, y):  # pylint: disable=g-doc-args
+  """`tf.where` which allows scalar inputs."""
+  if x.shape.rank == 0:
+    # This is to match the `tf.nn.*_rnn` behavior. In general, we might
+    # want to branch on `tf.reduce_all(condition)`.
+    return y
+  # TODO(tomhennigan) Broadcasting with SelectV2 is currently broken.
+  return tf1.where(condition, x, y)


### PR DESCRIPTION
Before trying to tackle #161 I thought it can be helpful to a bit simplify navigation in `recurrent.py` by reducing the number of lines of code there.
Carefully extracting few internal methods to another file seemed to be a quick win in that sense. So I decided to come up with this PR. Hopefully, it is useful for the maintainability of `recurrent.py`.

## Changes
- Moved following methods from `recurrent.py` to a new file `recurrent_internals.py` : 

| Method |
| --- |
| _check_inputs_dtype |
| _safe_where |
| _ unstack_input_sequence |
| _specialize_per_device |
| _rnn_step |
| _lstm_fn |
- Added `recurrent_internals.py` as a dependency to the Bazel `src/BUILD`
- Aligned the usage of recurrent_internals with the usage of utils


**The tests are passing locally**

## Questions
It was quite a useful journey for me and it would be great if you find the outcome useful as well:) I've also got a few questions while implementing the changes.
- [ ] Is `recurrent_internals.py` a good enough name? Please feel free to suggest a nicer or more consistent one.
- [ ] I’ve noticed quite a few TODOs in `recurrent.py`. Maybe you have some refactoring plans or ideas for this file which should be considered in the current or next PRs?
- [ ] Are there more places in code that should know about the newly added file?
