### PR TITLE
Error when using sonnet 2 and tensorflow 2.

### DIFF
--- a/sonnet/src/base.py
+++ b/sonnet/src/base.py
@@ -359,7 +359,7 @@ def allow_empty_variables(module_or_cls: T) -> T:
 def assert_tf2():
   if not assert_tf2.checked:
     with tf.init_scope():
-      assert tf.executing_eagerly(), "Sonnet v2 requires TensorFlow 2"
+      assert not tf.executing_eagerly(), "Sonnet v2 requires TensorFlow 2"
     assert_tf2.checked = True
 
 assert_tf2.checked = False


### PR DESCRIPTION
In tensorflow 2 eager execution is enabled by default.  Inverted the assert to check if it is not enabled instead.

Final error lines:

```console
    assert tf.executing_eagerly(), "Sonnet v2 requires TensorFlow 2"
AssertionError: Sonnet v2 requires TensorFlow 2
``` 

Here is the link to the documentation of tensorflow v2.8.0 (when I'm writing this) https://www.tensorflow.org/api_docs/python/tf/executing_eagerly, where they state that eager execution is enabled by default and thus the funciton will return true. In this case the assert will be triggered by default by using tensorflow 2 and sonnet 2. 

Configuration (Package=version): 
tensorflow-gpu=2.8.0rc0
tensorflow-probability=0.15.0
dm-sonnet=2.0.1.dev0
dm-tree=0.1.6
absl-py=1.0.0
numpy=1.22.0
tabulate=0.8.9
wrapt=1.13.3