### PR TITLE
Security: Unsafe use of exec() in version parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,18 @@
 """Setup for pip package."""
 
+import re
+
 from setuptools import find_namespace_packages
 from setuptools import setup
 
 
 def _get_sonnet_version():
   with open('sonnet/__init__.py') as fp:
-    for line in fp:
-      if line.startswith('__version__'):
-        g = {}
-        exec(line, g)  # pylint: disable=exec-used
-        return g['__version__']
-    raise ValueError('`__version__` not defined in `sonnet/__init__.py`')
+    content = fp.read()
+  match = re.search(r"__version__\s*=\s*['\"]([^'\"]+)['\"]", content)
+  if match:
+    return match.group(1)
+  raise ValueError('`__version__` not defined in `sonnet/__init__.py`')
 
 
 def _parse_requirements(requirements_txt_path):


### PR DESCRIPTION
## Problem

The _get_sonnet_version() function in setup.py uses exec() to parse the __version__ from sonnet/__init__.py. While currently reading from a controlled file, this pattern is dangerous as it could execute arbitrary code if the file is tampered with or if the function is repurposed to read user-controlled input.

**Severity**: `medium`
**File**: `setup.py`

## Solution

Replace exec() with a safer alternative such as regex extraction or ast.parse(). Example: re.search(r'__version__\s*=\s*["\']([^"\']+)["\']', content).group(1)

## Changes

- `setup.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
