### PR TITLE
Security: Dead code in read function - unused return value

### DIFF
--- a/sonnet/src/nets/dnc/read.py
+++ b/sonnet/src/nets/dnc/read.py
@@ -36,7 +36,7 @@ def read(memory,
   """
   with tf.name_scope("read_memory"):
     if squash_before_access:
-      squash_op(weights)
+      weights = squash_op(weights)
     read_word = tf.matmul(weights, memory)
     if squash_after_access:
       read_word = squash_op(read_word)


### PR DESCRIPTION
## Problem

In sonnet/src/nets/dnc/read.py, the squash_op(weights) call on line 36 has its return value discarded. The function is called for its side effect but the squashed result is never used, meaning the squash_before_access parameter has no effect.

**Severity**: `low`
**File**: `sonnet/src/nets/dnc/read.py`

## Solution

Either use the return value: weights = squash_op(weights), or remove the parameter if squashing before access is not needed.

## Changes

- `sonnet/src/nets/dnc/read.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
